### PR TITLE
Install cron job to automatically renew TLS certs

### DIFF
--- a/modules/compbox/manifests/init.pp
+++ b/modules/compbox/manifests/init.pp
@@ -473,6 +473,7 @@ class compbox (
             plugin  => nginx,
             domains => [$www_hostname] + $secondary_domains,
             require => Package['nginx', 'certbot'],
+            manage_cron => true,
             # Ensure the initial certificate request gets handled by the default
             # configuration as our custom config directly references the
             # certificate, which otherwise doesn't exist yet.


### PR DESCRIPTION
Previously, I believe the certificates were only checked when running an update, meaning they could easily expire. This PR adds a cron job to automatically check the certificate daily.

It should be using the `nginx` plugin, so `nginx` is automatically reloaded, but this will need testing once deployed (mostly by checking the command being run to confirm it's using the nginx plugin). The live certificate doesn't expire until after the competition (30th April), so leaving the box running until then would be another way to tell.

See https://github.com/voxpupuli/puppet-letsencrypt/tree/e12fb11a1b67c486ec11399de2dd34f95c25cb2b?tab=readme-ov-file#cron-using-certbot-certonly for more details.