### PR TITLE
Move internal srcomp-http socket onto loopback interface

### DIFF
--- a/modules/compbox/templates/http-wsgi.cfg.erb
+++ b/modules/compbox/templates/http-wsgi.cfg.erb
@@ -8,5 +8,5 @@ app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
     '/comp-api': app.wsgi_app
 })
 
-bind = '[::]:5112'
+bind = '[::1]:5112'
 keepalive = 5


### PR DESCRIPTION
Since this is an internal socket only intended for nginx, this should be in the loopback interface.