### PR TITLE
Fix being able to access pystream websocket

### DIFF
--- a/modules/compbox/templates/nginx.conf.erb
+++ b/modules/compbox/templates/nginx.conf.erb
@@ -42,7 +42,7 @@ server {
         add_header Access-Control-Allow-Origin *;
     }
 
-    # Allow the websocket to be reached at /stream/ws/
+    # Allow other paths of stream to be accessed.
     location /stream/ {
         proxy_pass http://127.0.0.1:5004/;
         proxy_redirect default;

--- a/modules/compbox/templates/nginx.conf.erb
+++ b/modules/compbox/templates/nginx.conf.erb
@@ -32,7 +32,18 @@ server {
         index stream.html;
     }
 
-    location /stream {
+    # Allow the eventstream to be accessible without the trailing slash
+    location = /stream {
+        proxy_pass http://127.0.0.1:5004/;
+        proxy_redirect default;
+        proxy_buffering off;
+        proxy_read_timeout 8m;
+
+        add_header Access-Control-Allow-Origin *;
+    }
+
+    # Allow the websocket to be reached at /stream/ws/
+    location /stream/ {
         proxy_pass http://127.0.0.1:5004/;
         proxy_redirect default;
         proxy_buffering off;


### PR DESCRIPTION
Nginx has slightly differenet semantics for proxy_pass inside a location whose identifier ends with a slash. In that case the request path gets added to the proxy URI to allow deeper pages to be reached.