### PR TITLE
Reload nginx after certbot

### DIFF
--- a/modules/compbox/manifests/init.pp
+++ b/modules/compbox/manifests/init.pp
@@ -441,6 +441,8 @@ class compbox (
                 '/etc/nginx/sites-enabled/default',
                 '/etc/nginx/sites-enabled/compbox',
             ],
+            # Ensure nginx is reloaded after each cron execution
+            cron_success_command => '/bin/systemctl reload nginx.service',
             notify  => Service['nginx'],
         }
     }


### PR DESCRIPTION
Turns out certbot won't do this automatically

As suggested in https://github.com/srobo/srcomp-puppet/pull/4#discussion_r1968367390, and already applied upstream in https://github.com/PeterJCLaw/srcomp-puppet/pull/29