### PR TITLE
Update staging screen to match table layout

### DIFF
--- a/modules/compbox/templates/screens-config.json.erb
+++ b/modules/compbox/templates/screens-config.json.erb
@@ -1,4 +1,7 @@
 {
     "apiurl": "/comp-api",
-    "streamurl": "/stream"
+    "streamurl": "/stream",
+    "displayConfig": {
+        "stagingCornersList": ["0", "3", "2", "1"]
+    }
 }


### PR DESCRIPTION
The table is currently set up in the order of corner 0, 3, 2 and 1. This sets the configuration option to ensure that the screen matching the layout on the table.

Depends on https://github.com/srobo/srcomp-screens/pull/19